### PR TITLE
Delete tag mapping when a file is deleted

### DIFF
--- a/DoomLauncher/Forms/MainForm.cs
+++ b/DoomLauncher/Forms/MainForm.cs
@@ -464,7 +464,10 @@ namespace DoomLauncher
             DirectoryDataSourceAdapter.DeleteGameFile(gameFile);
             DataSourceAdapter.DeleteGameFile(gameFile);
             if (gameFile.GameFileID.HasValue)
-                DataSourceAdapter.DeleteStatsByFile(gameFile.GameFileID.Value);           
+                DataSourceAdapter.DeleteStatsByFile(gameFile.GameFileID.Value);
+
+            var tagMapping = DataSourceAdapter.GetTagMappings(gameFile.GameFileID.Value);
+            tagMapping.ToList().ForEach(x => DataSourceAdapter.DeleteTagMapping(x));
         }
 
         private void DeleteLocalFileAssociations(IGameFile gameFIle)


### PR DESCRIPTION
Delete tag mapping when a file is deleted. This will prevent the data from being orphaned and possibly reused when a new file is downloaded after.