### PR TITLE
Set "CheckOnClick" on Specific to True

### DIFF
--- a/DoomLauncher/Forms/SpecificFilesForm.Designer.cs
+++ b/DoomLauncher/Forms/SpecificFilesForm.Designer.cs
@@ -102,6 +102,7 @@
             // 
             // clbFiles
             // 
+            this.clbFiles.CheckOnClick = true;
             this.clbFiles.Dock = System.Windows.Forms.DockStyle.Fill;
             this.clbFiles.FormattingEnabled = true;
             this.clbFiles.Location = new System.Drawing.Point(3, 83);


### PR DESCRIPTION
Doing this avoids having to sometimes doubleclick the checkbox to select a file. Noticed this when testing Utilities and selecting a file.